### PR TITLE
Added the -o option to allow more SSH options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ NOTE: Some linux users have reported problems using /etc/csshrc, but have had su
         -k, --access-key [KEY]           AWS access key
         -s, --secret-key [SECRET]        AWS secret key
         -r, --region [REGION]            AWS region
+        -o, --options [SSH_OPTIONS]      ssh options to pass directly to cssh
+
 
     $cluster -l ec2-user -t Name -v web,database
+    $cluster -o"-i /Path/to/key.pem" -t TagName -v database
 
 ## Contributing
 

--- a/bin/cluster
+++ b/bin/cluster
@@ -4,9 +4,10 @@ require 'optparse'
 require 'rubygems'
 require 'aws-sdk'
 
+
 options = {'tag' => 'role', 'user' => 'ec2-user'}
-OptionParser.new do |opts|
-  opts.banner = "Usage: cluster [-t TAG] [-l USER] [-k KEY -s SECRET] [-r region] -v VALUES"
+opt_parser = OptionParser.new do |opts|
+  opts.banner = "Usage: cluster [-t TAG] [-l USER] [-k KEY -s SECRET] [-r region] [-o SSH_OPTIONS] -v VALUES"
 
   opts.on("-l", "--login [USER]", "Log in with this user (default: #{options['user']}") do |opt|
     options['user'] = opt
@@ -31,7 +32,20 @@ OptionParser.new do |opts|
   opts.on("-r", "--region [REGION]", "AWS region") do |opt|
     options['region'] = opt
   end
+
+  #Allow -o to be passed to give specific ssh options
+  opts.on("-o", "--options [SSH_OPTIONS]", "ssh options to pass directly to cssh") do |opt|
+    options['SSH_OPTIONS'] = opt
+  end
+
+  #if no arguments are passed, print the help information and quit
+  if ARGV.length == 0
+    print opts.help()
+    exit
+  end
+
 end.parse!
+
 
 if !options['aws_secret_key'].nil? && !options['aws_access_key'].nil?
   AWS.config(access_key_id: options['aws_access_key'], secret_access_key: options['aws_secret_key'])
@@ -41,9 +55,15 @@ if !options['region'].nil?
   AWS.config(region: options['region'])
 end
 
+
 ec2 = AWS.ec2
 dns = ec2.instances.tagged(options['tag']).tagged_values(options['values']).map{|instance| instance.dns_name}
 
 cssh = (/darwin/ =~ RUBY_PLATFORM) ? 'csshX' : 'cssh'
 
-exec "#{cssh} -l #{options['user']} #{dns.join ' '}"
+# if options contain '-l' to specify user, and user is set, then don't specify user on the command
+if (options['SSH_OPTIONS'] =~ /\-l/) && (!options['user'].nil?)
+  exec "#{cssh} -o\"#{options['SSH_OPTIONS']}\"  #{dns.join ' '}"
+else 
+  exec "#{cssh} -l #{options['user']} -o\"#{options['SSH_OPTIONS']}\"  #{dns.join ' '}"
+end


### PR DESCRIPTION
The -o option will allow users to specify an ssh key or any other ssh parameter to CSSH from the command line
-o will take precedence over the -l parameter
Added in code to print the help message when no parameters were passed
