### PR TITLE
Changing aws-sdk to aws-sdk-ec2 to speed up gem launch time.

### DIFF
--- a/bin/cluster
+++ b/bin/cluster
@@ -2,7 +2,7 @@
 
 require 'optparse'
 require 'rubygems'
-require 'aws-sdk'
+require 'aws-sdk-ec2'
 
 options = {
   'use_public_ip'  => false,

--- a/ec2-clusterssh.gemspec
+++ b/ec2-clusterssh.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_dependency 'aws-sdk'
+  spec.add_dependency 'aws-sdk-ec2'
 end

--- a/lib/ec2/clusterssh/version.rb
+++ b/lib/ec2/clusterssh/version.rb
@@ -1,5 +1,5 @@
 module Ec2
   module Clusterssh
-    VERSION = "0.6.2"
+    VERSION = "0.6.3"
   end
 end


### PR DESCRIPTION
**Issues:**
1. Launching ec2-clusterssh takes 1-2 minutes when using the homebrew version of ruby-2.7.1.
2. The installation of ec2-clusterssh takes a long time because the entire aws-sdk needs to be downloaded.

**Solution:** 
Replace aws-sdk with aws-sdk-ec2. This limits the number of gems that need to be installed, and reduces the gem validation time on app startup. 